### PR TITLE
Include oldid field in {{db-g12}}

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1962,7 +1962,7 @@
 
 		// Copyright violations get {{db-g12}}'d as well
 		if ( declineReason === 'cv' && data.csdSubmission ) {
-			text.prepend( '{{db-g12|url=' + data.declineTextfield + ( data.copyvioUrl2 ? '|url2=' + data.copyvioUrl2 : '' ) + '|oldid=' + mw.config.get { 'wgCurRevisionId' ) + '}}\n' );
+			text.prepend( '{{db-g12|url=' + data.declineTextfield + ( data.copyvioUrl2 ? '|url2=' + data.copyvioUrl2 : '' ) + '|oldid=' + mw.config.get( 'wgCurRevisionId' ) + '}}\n' );
 			// Include copyvio urls in the decline template as well
 			newParams['3'] = data.declineTextfield + ( data.copyvioUrl2 ? ', ' + data.copyvioUrl2 : '' );
 		}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1962,7 +1962,7 @@
 
 		// Copyright violations get {{db-g12}}'d as well
 		if ( declineReason === 'cv' && data.csdSubmission ) {
-			text.prepend( '{{db-g12|url=' + data.declineTextfield + ( data.copyvioUrl2 ? '|url2=' + data.copyvioUrl2 : '' ) + '}}\n' );
+			text.prepend( '{{db-g12|url=' + data.declineTextfield + ( data.copyvioUrl2 ? '|url2=' + data.copyvioUrl2 : '' ) + '|oldid=' + mw.config.get { 'wgCurRevisionId' ) + '}}\n' );
 			// Include copyvio urls in the decline template as well
 			newParams['3'] = data.declineTextfield + ( data.copyvioUrl2 ? ', ' + data.copyvioUrl2 : '' );
 		}


### PR DESCRIPTION
This SHOULD include the current revision ID in the {{db-g12}} template to allow the copyvios and dupdet tools to work after the page is blanked. I haven't actually tested this, and I'm not sure that the correct revision ID will be inserted.