### PR TITLE
core.js: Remove unnecessary api submodule imports

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -186,8 +186,6 @@
 
 					// mediawiki.api
 					'mediawiki.api',
-					'mediawiki.api.category',
-					'mediawiki.api.titleblacklist',
 
 					// mediawiki plugins
 					'mediawiki.feedback'


### PR DESCRIPTION
All api submodules were merged into `mediawiki.api` in 1.33-wmf.16; avoids a console warning

Untested.