### PR TITLE
Allow G13 on unsubmitted drafts

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -326,9 +326,9 @@
 			return deferred.resolve( false );
 		}
 
-		// Userspace drafts and `Draft` namespace drafts must have
+		// Userspace drafts must have
 		// one or more AFC submission templates to be eligible
-		if ( [ 2, 118 ].indexOf( this.page.title.getNamespaceId() ) !== -1 &&
+		if ( this.page.title.getNamespaceId() == 2 &&
 			this.templates.length === 0 ) {
 			return deferred.resolve( false );
 		}


### PR DESCRIPTION
Restrict requiring the presence of an AfC submission template to userspace

Per https://en.wikipedia.org/wiki/WP:G13, "Any pages that have not been edited by a human in six months found in:
1. Draft namespace
2 Userspace with an {{AFC submission}} template...

There is no requirement that pages in the _draft_ namespace have an AfC template (be submitted and rejected) before they can be deleted.