### PR TITLE
core: Replace deprecated Morebits getUTCMonthName function

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -759,7 +759,8 @@
 				logPage.getText().done( function ( logText ) {
 					var status,
 						date = new Date(),
-						headerRe = new RegExp( '^==+\\s*' + date.getUTCMonthName() + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm' ),
+						monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+						headerRe = new RegExp( '^==+\\s*' + monthNames[date.getMonth()] + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm' ),
 						appendText = '';
 
 					// Don't edit if the page has doesn't exist or has no text
@@ -770,7 +771,7 @@
 
 					// Add header for new month if necessary
 					if ( !headerRe.test( logText ) ) {
-						appendText += '\n\n=== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ===';
+						appendText += '\n\n=== ' + monthNames[date.getMonth()] + ' ' + date.getUTCFullYear() + ' ===';
 					}
 
 					appendText += '\n# [[:' + options.title + ']]: ' + options.reason;

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -759,8 +759,8 @@
 				logPage.getText().done( function ( logText ) {
 					var status,
 						date = new Date(),
-						monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
-						headerRe = new RegExp( '^==+\\s*' + monthNames[date.getMonth()] + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm' ),
+						monthNames = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'] ,
+						headerRe = new RegExp( '^==+\\s*' + monthNames[ date.getMonth() ] + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm' ),
 						appendText = '';
 
 					// Don't edit if the page has doesn't exist or has no text
@@ -771,7 +771,7 @@
 
 					// Add header for new month if necessary
 					if ( !headerRe.test( logText ) ) {
-						appendText += '\n\n=== ' + monthNames[date.getMonth()] + ' ' + date.getUTCFullYear() + ' ===';
+						appendText += '\n\n=== ' + monthNames[ date.getMonth() ] + ' ' + date.getUTCFullYear() + ' ===';
 					}
 
 					appendText += '\n# [[:' + options.title + ']]: ' + options.reason;

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -759,7 +759,7 @@
 				logPage.getText().done( function ( logText ) {
 					var status,
 						date = new Date(),
-						monthNames = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'] ,
+						monthNames = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ],
 						headerRe = new RegExp( '^==+\\s*' + monthNames[ date.getMonth() ] + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm' ),
 						appendText = '';
 


### PR DESCRIPTION
`getUTCMonthName` is a function from Twinkle's Morebits library (https://github.com/azatoth/twinkle) but it was deprecated (discussed at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_42#Technical_changes_2; see in particular https://github.com/azatoth/twinkle/pull/928 and https://github.com/azatoth/twinkle/pull/635).  The AFCH gadget doesn't actually import the morebits library, so in theory the presence of this was broken for anybody who wasn't a Twinkle user.

Note that `wgMonthNames` was slated to be removed (See https://github.com/azatoth/twinkle/issues/723 and https://phabricator.wikimedia.org/T219340) although it may be around for a while.  I *think* `Date.toLocaleString` can be used, but that's a bit weird tbh.  Alternatively, this gadget could be reworked to actually require the morebits library, which could have some other ancillary benefits (e.g. the date header regex).