### PR TITLE
disable helper script on WP/WPT pages sans AfC/sandbox

### DIFF
--- a/src/afch.js
+++ b/src/afch.js
@@ -4,14 +4,12 @@
 	switch ( mw.config.get( 'wgNamespaceNumber' ) ) {
 		case 4: // Wikipedia
 		case 5: // Wikipedia talk
-			var i = -1;
 			var pageName = mw.config.get( 'wgTitle' );
-			while ( ++i < 22 ) { // 'Articles for creation/'.length === 22
-				if ( pageName.charCodeAt( i ) !== 'Articles for creation/'.charCodeAt( i ) ) {
-					return;
-				}
-			}
-			if ( pageName === 'Wikipedia:Articles_for_creation/Redirects' ) {
+			// return nothing for now, all drafts are now under Draft namespace
+			// currently only the article submission script is running here.
+			// to be used when script(s) for other modules such as category and
+			// redirect requests are reintergrated into here.
+			if ( pageName !== 'Articles for creation/sandbox' ) {
 				return;
 			}
 			break;


### PR DESCRIPTION
disable helper script for all of Wikipedia: and Wikipedia talk: namespace except for on AfC/sandbox. Running the helper script on WP:AFC pages and subpages is redundant for now given that drafts are now at Draft: namespace. should fix #133 as well.