### PR TITLE
Hide decline button when no reason is selected

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1933,7 +1933,7 @@
 				// If a reason has been specified, show the textarea, notify
 				// option, and the submit form button
 				$afch.find( '#declineTextarea' ).add( '#notifyWrapper' ).add( '#afchSubmitForm' )
-					.toggleClass( 'hidden', !reason );
+					.toggleClass( 'hidden', !reason || !reason.length );
 			} ); // End change handler for the decline reason select box
 
 			// And the the handlers for when a specific REJECT reason is selected
@@ -1943,7 +1943,7 @@
 				// If a reason has been specified, show the textarea, notify
 				// option, and the submit form button
 				$afch.find( '#rejectTextarea' ).add( '#notifyWrapper' ).add( '#afchSubmitForm' )
-					.toggleClass( 'hidden', !reason );
+					.toggleClass( 'hidden', !reason || !reason.length );
 			} ); // End change handler for the reject reason select box
 
 			// Attach the preview event listener

--- a/src/templates/tpl-submissions.html
+++ b/src/templates/tpl-submissions.html
@@ -286,7 +286,7 @@
 					cols="110" rows="3"></textarea>
 			</div>
 
-			<textarea id="declineTextarea" class="afch-input afch-textfield afch-textarea"
+			<textarea id="declineTextarea" class="afch-input afch-textfield afch-textarea hidden"
 				placeholder="Elaborate on your decline reason here using wikicode syntax."
 				cols="100" rows="5"></textarea>
 
@@ -297,7 +297,7 @@
 		</div>
 
 		<div id="rejectInputWrapper" class="hidden">
-			<textarea id="rejectTextarea" class="afch-input afch-textfield afch-textarea"
+			<textarea id="rejectTextarea" class="afch-input afch-textfield afch-textarea hidden"
 				placeholder="Elaborate on your reject reason here using wikicode syntax."
 				cols="100" rows="5"></textarea>
 		</div>


### PR DESCRIPTION
A possible solution to #145

I've decided to take a look at this issue and was able to come to a working solution. I've taken a different approach from the proposed solution so the code becomes more consistent with the comments: in them, it is implied that the textarea is hidden if there's no selected reason, so I've changed the textarea to be hidden by default and to toggle with the other elements.

Please let me know if this approach makes sense or if further changes are necessary.

https://user-images.githubusercontent.com/16337001/130522516-af6d5b9e-9e45-4e73-9471-95e3d6c4ea8c.mp4