### PR TITLE
Remove {{promising draft}}, and unify template removal logic

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -521,17 +521,17 @@
 			text = text.replace( /\[\[:Category:/gi, '[[Category:' );
 			text = text.replace( /\{\{(tl|tlx|tlg)\|(.*?)\}\}/ig, '{{$2}}' );
 
-			// Strip the AFC G13 postponement template
-			text = text.replace( /\{\{AfC postpone G13(?:\|\d*)?\}\}\n*/gi, '' );
+			var templatesToRemove = [
+				'AfC postpone G13',
+				'Draft topics',
+				'AfC topic',
+				'Drafts moved from mainspace',
+				'Promising draft'
+			];
 
-			// Remove draft topics template
-			text = text.replace( /\{\{draft topics\|(.*?)\}\}\n?/ig, '' );
-
-			// Remove AfC topic template
-			text = text.replace( /\{\{AfC topic\|(.*?)\}\}\n?/ig, '' );
-
-			// Remove drafts moved from mainspace template
-			text = text.replace( /\{\{Drafts moved from mainspace\|(.*?)\}\}\n?/ig, '' );
+			templatesToRemove.forEach( function ( template ) {
+				text = text.replace( new RegExp( '\\{\\{' + template + '\\s*\\|?(.*?)\\}\\}\\n?', 'gi' ), '' );
+			} );
 
 			// Add to the list of comments to remove
 			$.merge( commentsToRemove, [


### PR DESCRIPTION
also a cosmetic 2nd commit that changes all `'~~' + '~~'` to `~~~~`.

Closes #167.