### PR TITLE
Show copyvio url when not selecting speedy deletion

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2432,19 +2432,21 @@
 		}
 
 		// Copyright violations get {{db-g12}}'d as well
-		if ( ( declineReason === 'cv' || declineReason2 === 'cv' ) && data.csdSubmission ) {
+		if ( declineReason === 'cv' || declineReason2 === 'cv' ) {
 			var cvUrls = data.cvUrlTextarea.split( '\n' ).slice( 0, 3 ),
 				urlParam = '';
 
-			// Build url param for db-g12 template
-			urlParam = cvUrls[ 0 ];
-			if ( cvUrls.length > 1 ) {
-				urlParam += '|url2=' + cvUrls[ 1 ];
-				if ( cvUrls.length > 2 ) {
-					urlParam += '|url3=' + cvUrls[ 2 ];
+			if ( data.csdSubmission ) {
+				// Build url param for db-g12 template
+				urlParam = cvUrls[ 0 ];
+				if ( cvUrls.length > 1 ) {
+					urlParam += '|url2=' + cvUrls[ 1 ];
+					if ( cvUrls.length > 2 ) {
+						urlParam += '|url3=' + cvUrls[ 2 ];
+					}
 				}
+				text.prepend( '{{db-g12|url=' + urlParam + ( afchPage.additionalData.revId ? '|oldid=' + afchPage.additionalData.revId : '' ) + '}}\n' );
 			}
-			text.prepend( '{{db-g12|url=' + urlParam + ( afchPage.additionalData.revId ? '|oldid=' + afchPage.additionalData.revId : '' ) + '}}\n' );
 
 			// Include the URLs in the decline template
 			if ( declineReason === 'cv' ) {


### PR DESCRIPTION
Fixes issue #202, where the copyvio URL would not be shown if the option for speedy deletion wasn't selected. I've tested it and it works fine, see the below image for an example.
![image](https://user-images.githubusercontent.com/74876079/156252037-1c1c71d9-5475-45a9-84c3-8ac31a63eaa9.png)
