### PR TITLE
Add missing parentheses to Line 2559 to fix #103

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2556,7 +2556,7 @@
 
 					AFCH.actions.notifyUser( submitter, {
 						message: message,
-						summary: 'Notification: Your [[' + AFCH.consts.pagename + '|Articles for Creation submission]] has been ' + isDecline ? 'declined' : 'rejected'
+						summary: 'Notification: Your [[' + AFCH.consts.pagename + '|Articles for Creation submission]] has been ' + ( isDecline ? 'declined' : 'rejected' )
 					} );
 				} );
 			} );


### PR DESCRIPTION
This fixes https://github.com/WPAFC/afch-rewrite/issues/103 by adding missing parentheses to Line 2559 so that the part before "isDecline ? 'declined' : 'rejected'" correctly appears in the edit summary.