### PR TITLE
Allow admins to use the script (#130)

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -85,6 +85,9 @@
 				// Current user
 				user: mw.user.getName(),
 
+				// Is the user an admin?
+				userSysop: $.inArray('sysop', mw.config.get('wgUserGroups')) > -1,
+
 				// Edit summary ad
 				summaryAd: ' ([[WP:AFCH|AFCH]] ' + AFCH.consts.version + ')',
 
@@ -121,7 +124,7 @@
 				// three characters long on the list!
 				var $howToDisable,
 					sanitizedUser = user.replace( /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&' ),
-					userAllowed = ( new RegExp( '\\|\\s*' + sanitizedUser + '\\s*}' ) ).test( text );
+					userAllowed = ( new RegExp( '\\|\\s*' + sanitizedUser + '\\s*}' ) ).test( text ) || AFCH.consts.userSysop;
 
 				if ( !userAllowed ) {
 

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -85,9 +85,6 @@
 				// Current user
 				user: mw.user.getName(),
 
-				// Is the user an admin?
-				userSysop: $.inArray('sysop', mw.config.get('wgUserGroups')) > -1,
-
 				// Edit summary ad
 				summaryAd: ' ([[WP:AFCH|AFCH]] ' + AFCH.consts.version + ')',
 
@@ -124,7 +121,8 @@
 				// three characters long on the list!
 				var $howToDisable,
 					sanitizedUser = user.replace( /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&' ),
-					userAllowed = ( new RegExp( '\\|\\s*' + sanitizedUser + '\\s*}' ) ).test( text ) || AFCH.consts.userSysop;
+					userSysop = $.inArray('sysop', mw.config.get('wgUserGroups')) > -1,
+					userAllowed = (new RegExp('\\|\\s*' + sanitizedUser + '\\s*}')).test(text) || userSysop;
 
 				if ( !userAllowed ) {
 

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1782,7 +1782,7 @@
 							// current reviewer is not an admin, also display an error
 							// FIXME: offer one-click request unprotection?
 							$.each( data.query.pages[ '-1' ].protection, function ( _, entry ) {
-								if ( entry.type === 'create' && entry.level === 'sysop' && !AFCH.consts.userSysop ) {
+								if (entry.type === 'create' && entry.level === 'sysop' && $.inArray('sysop', mw.config.get('wgUserGroups')) === -1 ) {
 									errorHtml = 'Darn it, "' + linkToPage + '" is create-protected. You will need to request unprotection before accepting.';
 									buttonText = 'The proposed title is create-protected';
 								}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1782,8 +1782,7 @@
 							// current reviewer is not an admin, also display an error
 							// FIXME: offer one-click request unprotection?
 							$.each( data.query.pages[ '-1' ].protection, function ( _, entry ) {
-								if ( entry.type === 'create' && entry.level === 'sysop' &&
-									$.inArray( 'sysop', mw.config.get( 'wgUserGroups' ) ) === -1 ) {
+								if ( entry.type === 'create' && entry.level === 'sysop' && !AFCH.consts.userSysop ) {
 									errorHtml = 'Darn it, "' + linkToPage + '" is create-protected. You will need to request unprotection before accepting.';
 									buttonText = 'The proposed title is create-protected';
 								}


### PR DESCRIPTION
I set a AFCH.const.userSysop and checked against that. Obviously I'm not an admin and testwiki lets anyone use the script anyway, so this hasn't been tested except to confirm that AFCH.const.userSysop returns false for me.

I assume it's fine to take this issue given that the person assigned it hasn't commented there in a year, but let me know if this is some kind of horrible etiquette violation.