### PR TITLE
Userspace log of drafts

### DIFF
--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1192,7 +1192,7 @@
 				autoOpen: false,
 				logCsd: true,
 				launchLinkPosition: 'p-cactions',
-				logAfc: true
+				logAfc: false
 			};
 
 			/**

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -1190,7 +1190,7 @@
 				autoOpen: false,
 				logCsd: true,
 				launchLinkPosition: 'p-cactions',
-				logAfc: false
+				logAfc: true
 			};
 
 			/**

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -856,15 +856,25 @@
 				}
 
 				logPage.getText().done(function (logText) {
+					// Build log message
 					var header = AFCH.actions.addLogHeaderIfNeeded(logText);
 					var action = '\n# ' + options.actionType.charAt(0).toUpperCase() + options.actionType.slice(1)
 										+ (options.actionType === 'decline' ? '' : 'e') + 'd';
 					var title = ' [[:' + options.title + ']]';
+
+					var declineReason = '';
+					if (options.actionType === 'decline') {
+						console.log(options.declineReason);
+						console.log(options.declineReason2);
+						declineReason = ' (' + options.declineReason + (options.declineReason2 ? '/' + options.declineReason2 : '') + ')';
+					}
+
 					var byUser = ' by [[User:' + options.submitter + '|]]';
 					var sig = ' ~~' + '~~' + '~\n';
 
+					// Make log edit
 					logPage.edit({
-						contents: header + action + title + byUser + sig,
+						contents: header + action + title + declineReason + byUser + sig,
 						mode: 'appendtext',
 						summary: 'Logging ' + options.actionType + ' of [[' + options.title + ']]',
 						statusText: 'Logging ' + options.actionType + ' to'

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -857,12 +857,14 @@
 
 				logPage.getText().done(function (logText) {
 					var header = AFCH.actions.addLogHeaderIfNeeded(logText);
-					var actioningTitle = '\n# ' + options.actionType + 'ing [[:' + options.title + ']]';
+					var action = '\n# ' + options.actionType.charAt(0).toUpperCase() + options.actionType.slice(1)
+										+ (options.actionType === 'decline' ? '' : 'e') + 'd';
+					var title = ' [[:' + options.title + ']]';
 					var byUser = ' by [[User:' + options.submitter + '|]]';
 					var sig = ' ~~' + '~~' + '~\n';
 
 					logPage.edit({
-						contents: header + actioningTitle + byUser + sig,
+						contents: header + action + title + byUser + sig,
 						mode: 'appendtext',
 						summary: 'Logging ' + options.actionType + ' of [[' + options.title + ']]',
 						statusText: 'Logging ' + options.actionType + ' to'

--- a/src/modules/core.js
+++ b/src/modules/core.js
@@ -864,9 +864,11 @@
 
 					var declineReason = '';
 					if (options.actionType === 'decline') {
-						console.log(options.declineReason);
-						console.log(options.declineReason2);
-						declineReason = ' (' + options.declineReason + (options.declineReason2 ? '/' + options.declineReason2 : '') + ')';
+						// Custom is stored as 'reason' (because of template weirdness?), convert if necessary
+						options.declineReason = (options.declineReason === 'reason') ? 'custom' : options.declineReason;
+						options.declineReason2 = (options.declineReason2 === 'reason') ? 'custom' : options.declineReason2;
+
+						declineReason = ' (' + options.declineReason + (options.declineReason2 ? ' & ' + options.declineReason2 : '') + ')';
 					}
 
 					var byUser = ' by [[User:' + options.submitter + '|]]';

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2578,6 +2578,8 @@
 			AFCH.actions.logAfc({
 				title: afchPage.rawTitle,
 				actionType: isDecline ? "decline" : "reject",
+				declineReason: declineReason,
+				declineReason2: declineReason2,
 				submitter: submitter,
 			});
 

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -2366,7 +2366,18 @@
 							summary: 'Adding [[' + newPage + ']] to list of recent AfC creations'
 						} );
 					} );
-			} );
+
+				// LOG TO USERSPACE
+				// ----------
+
+				afchSubmission.getSubmitter().done(function (submitter) {
+					AFCH.actions.logAfc({
+						title: afchPage.rawTitle,
+						actionType: "accept",
+						submitter: submitter,
+					});
+				});
+			})
 	}
 
 	function handleDecline( data ) {
@@ -2562,18 +2573,25 @@
 			} );
 		}
 
-		// Log CSD if necessary
-		if ( data.csdSubmission ) {
-			// FIXME: Only get submitter if needed...?
-			afchSubmission.getSubmitter().done( function ( submitter ) {
-				AFCH.actions.logCSD( {
+		// Log AfC if enabled and CSD if necessary
+		afchSubmission.getSubmitter().done( function ( submitter ) {
+			AFCH.actions.logAfc({
+				title: afchPage.rawTitle,
+				actionType: isDecline ? "decline" : "reject",
+				submitter: submitter,
+			});
+
+
+			if (data.csdSubmission) {
+				AFCH.actions.logCSD({
 					title: afchPage.rawTitle,
 					reason: declineReason === 'cv' ? '[[WP:G12]] ({{tl|db-copyvio}})' :
 						'{{tl|db-reason}} ([[WP:AFC|Articles for creation]])',
-					usersNotified: data.notifyUser ? [ submitter ] : []
-				} );
-			} );
-		}
+					usersNotified: data.notifyUser ? [submitter] : []
+				});
+			 }
+		} );
+		
 	}
 
 	function handleComment( data ) {

--- a/src/templates/tpl-preferences.html
+++ b/src/templates/tpl-preferences.html
@@ -21,6 +21,10 @@
 		<label for="logCsd" class="afch-label">Log speedy deletion nominations</label>
 		<input type="checkbox" id="logCsd" class="afch-input" {{#logCsd}}checked{{/logCsd}} />
 	</div>
+	<div id="logAfcWrapper">
+		<label for="logAfc" class="afch-label">Log acceptances, declines, and rejects</label>
+		<input type="checkbox" id="logAfc" class="afch-input" {{#logAfc}}unchecked{{/logAfc}} />
+	</div>
 </div>
 <!-- /preferences -->
 

--- a/src/templates/tpl-preferences.html
+++ b/src/templates/tpl-preferences.html
@@ -23,7 +23,7 @@
 	</div>
 	<div id="logAfcWrapper">
 		<label for="logAfc" class="afch-label">Log acceptances, declines, and rejects</label>
-		<input type="checkbox" id="logAfc" class="afch-input" {{#logAfc}}unchecked{{/logAfc}} />
+		<input type="checkbox" id="logAfc" class="afch-input" {{#logAfc}}checked{{/logAfc}} />
 	</div>
 </div>
 <!-- /preferences -->


### PR DESCRIPTION
Resolves #134. Off by default, if enabled in preferences logs. Currently logs everything on one page with headers for the month, which might be inconvenient for really prolific reviewers.

Message for decline:
> \n# Declined [[:Title]] (reason1 & reason2) by [[User:Username|]] ~~~~~\n

Message for accept/reject:
> \n# [Accept/reject]ed [[:Title]] by [[User:Username|]] ~~~~~\n