### PR TITLE
switch to GitHub Actions continuous integration

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,16 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm install
+    - run: npm test
+      name: AFCH unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - node

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-afch-rewrite [![Build Status](https://travis-ci.org/WPAFC/afch-rewrite.png)](https://travis-ci.org/WPAFC/afch-rewrite) [![Release](https://img.shields.io/github/release/wpafc/afch-rewrite.svg)](https://github.com/WPAFC/afch-rewrite/releases)
+afch-rewrite [![Build Status](https://github.com/WPAFC/afch-rewrite/actions/workflows/unit_tests.yml/badge.svg)] [![Release](https://img.shields.io/github/release/wpafc/afch-rewrite.svg)](https://github.com/WPAFC/afch-rewrite/releases)
 ============
 
 **v0.9.1 Imperial Ibex**
@@ -24,7 +24,7 @@ To serve the script locally for development, use `npm start` and follow the inst
 ### Testing
 We have unit tests! `afch-rewrite` uses [Jest](https://github.com/facebook/jest) for testing, a framework built on top of Jasmine that offers dead-simple mocking, built-in simulated DOM manipulation using [jsdom](https://github.com/tmpvar/jsdom), and more.
 
-Tests are stored in the `__tests__` directory and are run automatically on new commits via Travis.
+Tests are stored in the `__tests__` directory and are run automatically on new commits via GitHub Actions.
 
 ### Uploading and releasing the script
 To upload the script to a wiki, use `scripts/upload.py`. Detailed instructions are included at the top of the file.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,7 +1,7 @@
 Style guide
 ===========
 
-For the most part, we follow [MediaWiki coding conventions](https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript). Code should validate with JSHint (see configuration in `.jshintrc`) as well as JSCS (see configuration in `.jscsrc`). Travis CI is used to ensure consistent code style/quality; tests are run on all commits and pull requests.
+For the most part, we follow [MediaWiki coding conventions](https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript). Code should validate with JSHint (see configuration in `.jshintrc`) as well as JSCS (see configuration in `.jscsrc`). GitHub Actions is used to ensure consistent code style/quality; tests are run on all commits and pull requests.
 
 ## Tips
  * _**TABS!**_


### PR DESCRIPTION
Unit test continuous integration (where the unit tests are run with every PR or commit, and a green check mark or red X displays depending on whether the unit tests pass or fail) is not currently working.

There may be a way to fix Travis CI, but this patch instead replaces Travis CI with GitHub Actions. That way everything is under one roof, which should be easier for maintainability.

Having unit tests + CI is an important bump to the maintainability of any project.

Unable to fully test since CI hasn't run on this PR yet. But this should get us started. I'll do a follow up PR, if needed.