### PR TITLE
fix toomanyvalues API error

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1489,8 +1489,10 @@
 
 			// If any templates weren't in the WikiProject map, check if they were redirects
 			if ( otherTemplates.length > 0 ) {
-				var titles = otherTemplates.map( function ( n ) { return 'Template:' + n; } ).join( '|' );
-				return AFCH.api.get( {
+				var titles = otherTemplates.map( function ( n ) { return 'Template:' + n; } );
+				titles = titles.slice( 0, 50 ); // regular users (non-admins, non-bots) will get API error if requesting more than 50 templates at a time
+				titles = titles.join( '|' );
+				return AFCH.api.post( {
 					action: 'query',
 					titles: titles,
 					redirects: 'true'

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1490,7 +1490,7 @@
 			// If any templates weren't in the WikiProject map, check if they were redirects
 			if ( otherTemplates.length > 0 ) {
 				var titles = otherTemplates.map( function ( n ) { return 'Template:' + n; } );
-				titles = titles.slice( 0, 50 ); // regular users (non-admins, non-bots) will get API error if requesting more than 50 templates at a time
+				titles = titles.slice( 0, 50 ); // prevent API error by capping max # of titles at 50
 				titles = titles.join( '|' );
 				return AFCH.api.post( {
 					action: 'query',


### PR DESCRIPTION
Fix #238

Also change from "get" to "post" to prevent a large # of templates from hitting the max URL length (2048 characters)