### PR TITLE
remove "next very old submission"

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1302,10 +1302,9 @@
 				);
 
 			// Show a link to the next random submissions
-			new AFCH.status.Element( 'Continue to next $1, $2, or $3 &raquo;', {
+			new AFCH.status.Element( 'Continue to next $1 or $2 &raquo;', {
 				$1: AFCH.makeLinkElementToCategory( 'Pending AfC submissions', 'random submission' ),
-				$2: AFCH.makeLinkElementToCategory( 'AfC pending submissions by age/0 days ago', 'zero-day-old submission' ),
-				$3: AFCH.makeLinkElementToCategory( 'AfC pending submissions by age/Very old', 'very old submission' )
+				$2: AFCH.makeLinkElementToCategory( 'AfC pending submissions by age/0 days ago', 'zero-day-old submission' )
 			} );
 
 			// Also, automagically reload the page in place


### PR DESCRIPTION
Requested by Slywriter at https://en.wikipedia.org/wiki/Wikipedia_talk:WikiProject_Articles_for_creation#AFCH%3A_next_%22very_old%22_submission

The "next very old submission" category is always empty, since we never have drafts older than 6 months. So no need to market the link in such a high profile place. If folks want to visit this category, they can do so via https://en.wikipedia.org/wiki/Template:AfC_pending_submissions_by_age_(category_header) or similar

Before:
<img width="1036" alt="2022-08-10_015824" src="https://user-images.githubusercontent.com/79697282/183861550-cc68ae1d-1751-47c7-93b0-4b908247dab9.png">

After:
<img width="1032" alt="2022-08-10_020029" src="https://user-images.githubusercontent.com/79697282/183861558-e9ba2c2f-c128-403e-a524-b4c0934e7b76.png">